### PR TITLE
1 documentation update

### DIFF
--- a/docker/deploy/containers-setup-app.sh
+++ b/docker/deploy/containers-setup-app.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # sets up the containers ready for use.
 # once complete run them with run-containers.sh

--- a/docker/deploy/containers-setup-core.sh
+++ b/docker/deploy/containers-setup-core.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # sets up the containers ready for use.
 # once comple run them with run-containers.sh

--- a/docker/deploy/images-build-core.sh
+++ b/docker/deploy/images-build-core.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 cd images
 docker build -t squonk/xwiki -f Dockerfile-xwiki .

--- a/docker/deploy/images-build-services.sh
+++ b/docker/deploy/images-build-services.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # builds the docker images that are based on our code.
 # To be safe run this every time, or just update the containers

--- a/docker/deploy/images-pull-extra.sh
+++ b/docker/deploy/images-pull-extra.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 docker pull rabbitmq:3-management
 docker pull nginx:1.13

--- a/docker/deploy/images-pull-squonk.sh
+++ b/docker/deploy/images-pull-squonk.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 docker pull squonk/chem-services-basic
 docker pull squonk/core-services-server

--- a/docker/deploy/images-push.sh
+++ b/docker/deploy/images-push.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 base=$PWD
 

--- a/docker/deploy/setenv-default.sh
+++ b/docker/deploy/setenv-default.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 #@IgnoreInspection BashAddShebang
 # The environment variable for PRIVATE_HOST will be the address of the docker gateway, something like 172.17.0.1
 # The environment variable for PUBLIC_HOST will be the public address, something like squonk.it or the IP of the gateway
@@ -6,8 +8,8 @@
 # docker network inspect deploy_squonk_front
 #
 
-export PUBLIC_HOST=172.20.0.1
-export PRIVATE_HOST=172.20.0.1
+export PUBLIC_HOST=172.17.0.1
+export PRIVATE_HOST=172.17.0.1
 export RABBITMQ_ERLANG_COOKIE=topsecret
 
 # password for the admin user of rabbitmq

--- a/docker/deploy/ubunutu-setup.md
+++ b/docker/deploy/ubunutu-setup.md
@@ -121,8 +121,8 @@ cd ..
 Now pull the docker images. This will take a few mins.
 ```sh
 cd squonk/docker/deploy
-./images=pull-squonk.sh
-./images=pull-extra.sh
+./images-pull-squonk.sh
+./images-pull-extra.sh
 ```
 
 ### Copy the keys

--- a/docker/deploy/ubunutu-setup.md
+++ b/docker/deploy/ubunutu-setup.md
@@ -5,17 +5,27 @@
 ### Install the goodies
 
 This is based on Ubuntu Xenial server running on [Scaleway](https://cloud.scaleway.com). 
-This was tested using a X64-15GB server.
+This was tested using a X64-15GB server and a C2M 8-core 16GB server.
+Depending on your privileges you may need to sudo some comamnds.
 
 ```sh
-apt-get update
-apt-get install -y git curl jq apt-transport-https ca-certificates software-properties-common openjdk-8-jdk
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-apt-get update
-apt-get install -y docker-ce
+# apt-get update
+# apt-get install -y git curl jq apt-transport-https ca-certificates software-properties-common openjdk-8-jdk
+# curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+# add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+# apt-get update
+# apt-cache search docker-ce
+# apt-get install -y docker-ce
 ```
 
+The above `search` avoid the following error:
+
+    # apt-get install -y docker-ce
+    Reading package lists... Done
+    Building dependency tree       
+    Reading state information... Done
+    E: Unable to locate package docker-ce
+    
 To test docker:
 
 ```sh
@@ -31,27 +41,26 @@ curl -L https://github.com/docker/compose/releases/download/1.14.0/docker-compos
 And command line completions
 
 ```sh
-curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker > /etc/bash_completion.d/docker
-curl -L https://raw.githubusercontent.com/docker/compose/master/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
+# curl -L https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker > /etc/bash_completion.d/docker
+# curl -L https://raw.githubusercontent.com/docker/compose/master/contrib/completion/bash/docker-compose -o /etc/bash_completion.d/docker-compose
 ```
 
 Check permissions on the docker-compose executable found in /usr/local/bin. If not set to be executable do this:
 
 ```sh
-chmod 755 /usr/local/bin/docker-compose
+# chmod 755 /usr/local/bin/docker-compose
 ```
 
 Install certbot:
 
 ```sh
-add-apt-repository ppa:certbot/certbot
-apt-get update
-apt-get install -y certbot
+# add-apt-repository -y ppa:certbot/certbot
+# apt-get update
+# apt-get install -y certbot
 ```
 
 Alternatively if there is no packaged version of cerbot for your system you can use certbot-auto.
 See [here](https://certbot.eff.org/all-instructions/#ubuntu-other-nginx) for more.
-
 
 ### Setup the SSL certificates
 
@@ -65,38 +74,73 @@ It partly follows a description found [here](https://www.digitalocean.com/commun
 Generate certificate. If your not already registered with Let's Encrypt then do this and you need to answer various questions:
 
 ```sh
-certbot certonly --standalone -d squonk.informaticsmatters.com
+# certbot certonly --standalone -d squonk.informaticsmatters.com
 ```
 
 If you are already registered you can avoid this using:
 
 ```ssh
-certbot certonly --standalone -n -m your@email.address --agree-tos -d squonk.informaticsmatters.com 
+# certbot certonly --standalone -n -m your@email.address --agree-tos -d squonk.informaticsmatters.com 
 
 ```
 (replace squonk.informaticsmatters.com with your actual domain and your@email.address with the email you are registed as).
 The certs will be in /etc/letsencrypt/live/<domain name>
 
-
 Generate Strong Diffie-Hellman Group:
 
+>   The Diffie–Hellman key exchange method allows two parties
+    that have no prior knowledge of each other to jointly
+    establish a shared secret key over an insecure channel.
+
 ```sh
-openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048
+# openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048
 ```
 This takes a few mins.
 
-
 ### Create the Squonk user
+Adding it to the `docker` and `sudo` group...
 
 ```sh
-useradd -m squonk -s /bin/bash
-gpasswd -a squonk docker
-gpasswd -a squonk sudo
+# useradd -m squonk -s /bin/bash
+# gpasswd -a squonk docker
+# gpasswd -a squonk sudo
 ```
 
-For that user add public key to $HOME/.ssh/authorized_keys.
+### SSH and a key-pair
+Create a key pair (on your client):
+
+```
+$ ssh-keygen -t rsa -b 4096
+Generating public/private rsa key pair.
+Enter file in which to save the key (/Users/abc/.ssh/id_rsa): /Users/abc/.ssh/squonk_rsa
+Enter passphrase (empty for no passphrase): 
+Enter same passphrase again: 
+Your identification has been saved in /Users/abc/.ssh/squonk_rsa.
+Your public key has been saved in /Users/abc/.ssh/squonk_rsa.pub.
+The key fingerprint is:
+SHA256:7qxB0Cd5dx9IYdfNGpKVtYaNiWAMtIUwKA4P5GWdsTY abc@Dallas.local
+The key's randomart image is:
++---[RSA 4096]----+
+|.. oo+=o++  ++o=o|
+|+.o. +oo+..o+oB =|
+|o+. .E+.o ..o=.* |
+| .. ...+ . . .o. |
+|      . S     .  |
+|     . .         |
+|      . .        |
+|       +         |
+|      ..o        |
++----[SHA256]-----+
+```
+
+Create or append to the squonk user's `.ssh/authorized_keys` file on the new server.
+Here you're copying the public key content form your client.
+Remember to set the permisssions of this file to 600:
+
+    $ chmod 600 ~/.ssh/authorized_keys
+
 Test you can login as that user with ssh.
-Adjust sshd settings in /etc/ssh/sshd_config according to your needs.
+Adjust sshd settings in `/etc/ssh/sshd_config` according to your needs.
 
 ## Squonk setup
 
@@ -104,90 +148,155 @@ Login as squonk user
 Make sure JAVA_HOME is set using something like this:
 
 ```sh
-export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+$ export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 ```
-Best to put this in your $HOME/.profile
+
+>   Best to put this in your `$HOME/.profile`.
 
 ```sh
-mkdir git
-cd git
-git clone https://github.com/InformaticsMatters/squonk.git
-git clone https://github.com/InformaticsMatters/pipelines.git
-cd pipelines
-./copy.dirs.sh
-cd ..
+$ mkdir git
+$ cd git
+$ git clone https://github.com/InformaticsMatters/squonk.git
+$ git clone https://github.com/InformaticsMatters/pipelines.git
+$ cd pipelines
+$ ./copy.dirs.sh
+$ cd ..
 ```
 
 Now pull the docker images. This will take a few mins.
 ```sh
-cd squonk/docker/deploy
-./images-pull-squonk.sh
-./images-pull-extra.sh
+$ cd squonk/docker/deploy
+$ ./images-pull-squonk.sh
+$ ./images-pull-extra.sh
 ```
 
 ### Copy the keys
 
 ```sh
-mkdir -p images/nginx/certs/squonk
-cp /etc/ssl/certs/dhparam.pem images/nginx/certs/squonk/
-sudo cp /etc/letsencrypt/live/squonk.informaticsmatters.com/fullchain.pem images/nginx/certs/squonk/
-sudo cp /etc/letsencrypt/live/squonk.informaticsmatters.com/privkey.pem images/nginx/certs/squonk/
+$ mkdir -p images/nginx/certs/squonk
+$ cp /etc/ssl/certs/dhparam.pem images/nginx/certs/squonk/
+$ sudo cp /etc/letsencrypt/live/squonk.informaticsmatters.com/fullchain.pem images/nginx/certs/squonk/
+$ sudo cp /etc/letsencrypt/live/squonk.informaticsmatters.com/privkey.pem images/nginx/certs/squonk/
 ```
+
+>   Remember to use the URL you used when setting up certbot.
 
 Alternatively, if you are running locally and don't need trusted certificates you can use self signed ones.
 The browser will complain and you will need to accept you are using non-trusted certificates.
 Do this using something like:
 
 ```sh
-mkdir -p images/nginx/certs/squonk
-openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout images/nginx/certs/squonk/privkey.pem -out images/nginx/certs/squonk/fullchain.pem
+$ mkdir -p images/nginx/certs/squonk
+$ openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout images/nginx/certs/squonk/privkey.pem -out images/nginx/certs/squonk/fullchain.pem
 ```
-You should also create the dhparam.pem file like this:
+
+Whether you're using official certificates or untrusted ones
+you should also create the `dhparam.pem` file like this:
 
 ```sh
-openssl dhparam -out images/nginx/certs/squonk/dhparam.pem 2048
+$ openssl dhparam -out images/nginx/certs/squonk/dhparam.pem 2048
 ```
 
 ### Copy license files
 
 Currently this involves ChemAxon and CPSign licenses. Copy them to data/licenses. 
 
+-   `license.cxl` is the ChemAxon licence file
+-   ``
+
+### Setup gradle properties
+Before starting you need to provide details of the ChemAxon maven rpository.
+This goes into Squonk's `~/.gradle/gradle.properties` file and consists of
+(`cnx-stuff.txt`):
+
+```
+cxnMavenUser=<USER-EMAIL>
+cxnMavenPassword=<ENCYPTED-USER-PASSWORD>
+cxnMavenRepositoryUrl=https://hub.chemaxon.com/artifactory/libs-release
+```
+
+If you don't, you're likely to see the following error
+running `./containers-setup-app.sh` later in these notes:
+
+```
+A problem occurred evaluating root project 'components'.
+> Could not get unknown property 'cxnMavenRepositoryUrl' for object
+       of type org.gradle.api.internal.artifacts.repositories.DefaultMavenArtifactRepository.
+```
+    
 ### Configure and run
+From within the `~/git/squonk/docker/deploy` directory...
 
 ```sh
-cp setenv-default.sh setenv.sh
+$ cp setenv-default.sh setenv.sh
 ```
 
-Now edit setenv.sh to set passwords etc.
-You MUST set the value of PUBLIC_HOST to the external FQDN of your server (or the IP address of the docker bridge network
-if you are running locally).
+Now edit `setenv.sh` to set passwords etc.
+You MUST set the value of PUBLIC_HOST to the external FQDN of your server
+(or the IP address of the docker bridge network if you are running locally).
 
 ```sh 
-source setenv.sh
-./containers-setup-core.sh
-./containers-setup-app.sh
+$ source setenv.sh
 ```
+
+>   You could add `source ~/git/squonk/docker/deploy/setenv.sh` to squonk's `.profile`.
+
+```
+$ ./containers-setup-core.sh
+```
+
+This will have started, configured and then stopped the following services
+(container images):
+
+-   keycloak (jboss/keycloak-postgres)
+-   rabbitmq (rabbitmq)
+-   postgres (informaticsmatters/rdkit_cartridge)
+
+```
+$ ./containers-setup-app.sh
+```
+
+This will have started Postgress and Keycloak and configured the database
+but all container images will have been stopped.
 
 Finally, we are ready to run:
 
 ```sh
-./containers-run.sh
+$ ./containers-run.sh
 ```
 
-Due to a glitch that is still to be resolved the nginx container takes some time to start. Monitor the status using
-`docker-compose ps`. You might even need to do a `docker-compose start nginx` if that container fails to start. 
+This should start the following services (containers). The xwiki
+is normally only used on the production site.
+
+-   nginx (nginx)
+-   portal (squonk/portal)
+-   coreservices (squonk/coreservices)
+-   cellexecutor (squonk/cellexecutor)
+-   chemservices (squonk/chemservices)
+-   keycloak (jboss/keycloak-postgres)
+-   rabbitmq (rabbitmq)
+-   postgres (informaticsmatters/rdkit_cartridge)
+
+Two busybox containers will have been stared and stopped (these provide
+synchronisation between the services).
+
+>   Due to a glitch that is still to be resolved the nginx container takes
+    some time to start. Monitor the status using `docker-compose ps`.
+    You might even need to do a `docker-compose start nginx` if that container fails to start. 
 
 Check that the site is reachable and forwards http traffic to https.
+
 Check the SSL status using Qualys SSL Labs Report by opening this in web browser.
 https://www.ssllabs.com/ssltest/analyze.html?d=squonk.informaticsmatters.com
 
 
 You can login using one of the built in accounts, user1 and user2, which have passwords the same as the username.
-NOTE: to make the site safe you should delete these accounts or change the passwords uing the admin console which
-will be found at a url like this:
-https://squonk.informaticsmatters.com/auth
-Log in as the admin user using the KEYCLOAK_USER username and KEYCLOAK_PASSWORD password that you defined in setup.sh.
 
+>   NOTE: to make the site safe you should delete these accounts or change
+    the passwords uing the admin console which will be found at a url like this:
+    `https://squonk.informaticsmatters.com/auth`. Log in as the admin user
+    using the `KEYCLOAK_USER` username and `KEYCLOAK_PASSWORD` password that
+    you defined in `setenv.sh`.
 
 ## Certificate renewal
 
@@ -226,5 +335,3 @@ To renew certificate manually do this:
 certbot renew
 ```
 And then copy the certs as above.
-
-


### PR DESCRIPTION
- Adjustments to `ubuntu-setup.md` after Scaleway trial
- Adjusts a number of shell-script shebang lines for consistency
- setenv-default.sh now uses 172.17.0.1 for PUBLIC/PRIVATE HOST
  this aligns with the comments in the file. They're also lines the user
  normally changes anyway so should be low-risk.

