### PR TITLE
Issue 34

### DIFF
--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -420,8 +420,8 @@ public class OpenShiftRunner extends AbstractRunner {
      * Given an existing configuration string this method adds material
      * to allow a Nextflow container to run properly in our OpenShift
      * environment. This mainly consists of exposing the name of the
-     * shared data volume claim, a suitable mount path and the sub-path
-     * we're using.
+     * shared data volume claim, a suitable mount path, the sub-path
+     * we're using and the service account for the namespace we're in.
      *
      * @param originalConfig The original configuration string.
      *                       If this is null, null is returned.
@@ -441,10 +441,12 @@ public class OpenShiftRunner extends AbstractRunner {
                 "  storageClaimName = '%s'\n" +
                 "  storageMountPath = '%s'\n" +
                 "  storageSubPath = '%s'\n" +
+                "  serviceAccount = '%s'\n" +
                 "}\n",
                 OS_DATA_VOLUME_PVC_NAME,
                 localWorkDir,
-                jobId);
+                jobId,
+                OS_SA);
 
         return originalConfig + "\n" + additionalConfig;
 

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -550,7 +550,7 @@ public class OpenShiftRunner extends AbstractRunner {
                 .endMetadata()
                 .withNewSpec()
                 .withContainers(podContainer)
-//                .withServiceAccount(OS_SA)
+                .withServiceAccount(OS_SA)
                 .withRestartPolicy(OS_POD_RESTART_POLICY)
                 .withVolumes(volume)
                 .endSpec().build();

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/steps/impl/DatasetNextflowInDockerExecutorStep.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/steps/impl/DatasetNextflowInDockerExecutorStep.java
@@ -88,10 +88,10 @@ public class DatasetNextflowInDockerExecutorStep extends AbstractContainerStep {
             // There may be nothing to add but the returned string
             // will be valid.
             nextflowConfigContents = runner.addExtraNextflowConfig(nextflowConfigContents);
-            LOG.fine("Writing nextflow.config as:\n" + nextflowConfigContents);
+            LOG.info("Writing nextflow.config as:\n" + nextflowConfigContents);
             runner.writeInput("nextflow.config", nextflowConfigContents, false);
         } else {
-            LOG.fine("No nextflow.config");
+            LOG.info("No nextflow.config");
         }
 
         // The runner's either a plain Docker runner

--- a/openshift/templates/squonk-app/squonk-app-components.yaml
+++ b/openshift/templates/squonk-app/squonk-app-components.yaml
@@ -365,6 +365,8 @@ objects:
             value: ${CELL_JOB_PROJECT_NAME}
           - name: SQUONK_POD_BASE_NAME
             value: ${CELL_SQUONK_POD_BASE_NAME}
+          - name: SQUONK_SERVICE_ACCOUNT
+            value: ${APP_SA}
           - name: SQUONK_POD_LOG_HISTORY
             value: ${CELL_JOB_LOG_HISTORY}
           - name: SQUONK_NEXTFLOW_IMAGE


### PR DESCRIPTION
- SQUONK_SERVICE_ACCOUNT now set in cellexecutor DC
- Nextflow config low logged using "info" (was "fine")
- SA now correctly set in nextflow pod
- Adds `serviceAccount` to k8s config