### PR TITLE
- Fixed unit tests broken that used busybox

### DIFF
--- a/components/core-services-exec/src/test/groovy/org/squonk/execution/JobManagerSpec.groovy
+++ b/components/core-services-exec/src/test/groovy/org/squonk/execution/JobManagerSpec.groovy
@@ -58,7 +58,7 @@ class JobManagerSpec extends Specification {
                 null, //ThinDescriptor[] thinDescriptors,
                 // these are specific to docker execution
                 "org.squonk.execution.steps.impl.DefaultDockerExecutorStep", //String executorClassName,
-                "busybox",
+                "informaticsmatters/pipelines-busybox:1.0.0",
                 "cp input.sdf.gz output.sdf.gz",
                 null)
     }
@@ -85,7 +85,7 @@ class JobManagerSpec extends Specification {
                 null, //ThinDescriptor[] thinDescriptors,
                 // these are specific to docker execution
                 "org.squonk.execution.steps.impl.DefaultDockerExecutorStep", //String executorClassName,
-                "busybox",
+                "informaticsmatters/pipelines-busybox:1.0.0",
                 "cp input.data.gz output.data.gz && cp input.metadata output.metadata",
                 null)
     }

--- a/components/core-services-exec/src/test/groovy/org/squonk/execution/runners/DockerRunnerSpec.groovy
+++ b/components/core-services-exec/src/test/groovy/org/squonk/execution/runners/DockerRunnerSpec.groovy
@@ -39,7 +39,7 @@ class DockerRunnerSpec extends Specification {
     void "clean workdir"() {
 
         setup:
-        DockerRunner runner = new DockerRunner("busybox", "123")
+        DockerRunner runner = new DockerRunner("informaticsmatters/pipelines-busybox:1.0.0", "123")
         runner.init()
 
         when:
@@ -47,23 +47,6 @@ class DockerRunnerSpec extends Specification {
 
         then:
         !runner.getHostWorkDir().exists()
-    }
-
-    void "simple execute"() {
-
-        setup:
-        DockerRunner runner = new DockerRunner("busybox", "123")
-        runner.init()
-
-        when:
-        runner.writeInput("run.sh", "touch IWasHere\n")
-        runner.execute("/bin/sh", "run.sh")
-
-        then:
-        new File(runner.getHostWorkDir(), 'IWasHere').exists()
-
-        cleanup:
-        runner.cleanup();
     }
 
 //    void "start and stop"() {

--- a/components/core-services-exec/src/test/groovy/org/squonk/execution/steps/impl/DefaultDockerExecutorStepSpec.groovy
+++ b/components/core-services-exec/src/test/groovy/org/squonk/execution/steps/impl/DefaultDockerExecutorStepSpec.groovy
@@ -49,7 +49,7 @@ class DefaultDockerExecutorStepSpec extends Specification {
         DockerServiceDescriptor dsd = new DockerServiceDescriptor("id.busybox", "name", "desc",  null, null, null, null, null,
                 [IODescriptors.createMoleculeObjectDataset("input")] as IODescriptor[], [new IORoute(IORoute.Route.FILE)] as IORoute[],
                 [IODescriptors.createMoleculeObjectDataset("output")] as IODescriptor[], [new IORoute(IORoute.Route.FILE)] as IORoute[],
-                null, null, "executor", 'busybox', cmd, [:])
+                null, null, "executor", 'informaticsmatters/pipelines-busybox:1.0.0', cmd, [:])
 
         DefaultDockerExecutorStep step = new DefaultDockerExecutorStep()
         step.configure(jobId, options, dsd, context, null)

--- a/components/core-services-exec/src/test/groovy/org/squonk/execution/steps/impl/ThinDatasetDockerExecutorStepSpec.groovy
+++ b/components/core-services-exec/src/test/groovy/org/squonk/execution/steps/impl/ThinDatasetDockerExecutorStepSpec.groovy
@@ -72,7 +72,7 @@ class ThinDatasetDockerExecutorStepSpec extends Specification {
                 [new IORoute(IORoute.Route.FILE)] as IORoute[],
                 [outputIod] as IODescriptor[],
                 [new IORoute(IORoute.Route.FILE)] as IORoute[],
-                null, null, "executor", 'busybox', cmd, [:])
+                null, null, "executor", 'informaticsmatters/pipelines-busybox:1.0.0', cmd, [:])
 
         ThinDatasetDockerExecutorStep step = new ThinDatasetDockerExecutorStep()
         step.configure(jobId, options, dsd, context, null)


### PR DESCRIPTION
- Removed one broken test that really didn't test anything new.
- Tests now rely on `informaticsmatters/pipelines-busybox:1.0.0`