### PR TITLE
102 pull secret

### DIFF
--- a/components/core-services-common/src/main/java/org/squonk/core/DockerServiceDescriptor.java
+++ b/components/core-services-common/src/main/java/org/squonk/core/DockerServiceDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Informatics Matters Ltd.
+ * Copyright (c) 2020 Informatics Matters Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,7 @@ public class DockerServiceDescriptor extends DefaultServiceDescriptor {
      * @param thinDescriptors   Descriptors for thin execution
      * @param executorClassName The class name of the executor
      * @param imageName         Docker image to use if not overriden by one of the user defined options (e.g. if there is a choice of images to use).
+     * @param imagePullSecret   The name of a secret required to pull the Docker image, empty if not required (used for Kubernetes deployments).
      * @param command           The command to run when executing the container.
      * @param volumes           Volumes that need to be mounted. Primarily the volume that contains the scripts to execute. The key is the directory to
      *                          mount (relative to the configured directory that contains mountable volumes), the value is where to mount it in
@@ -113,6 +114,7 @@ public class DockerServiceDescriptor extends DefaultServiceDescriptor {
             // these are specific to docker execution
             String executorClassName,
             String imageName,
+            String imagePullSecret,
             String command,
             Map<String, String> volumes) {
 
@@ -121,6 +123,7 @@ public class DockerServiceDescriptor extends DefaultServiceDescriptor {
                 thinDescriptors, inputRoutes, outputRoutes);
 
         this.imageName = imageName;
+        this.imagePullSecret = imagePullSecret;
         this.command = command;
         this.volumes = volumes;
     }

--- a/components/core-services-common/src/main/java/org/squonk/core/DockerServiceDescriptor.java
+++ b/components/core-services-common/src/main/java/org/squonk/core/DockerServiceDescriptor.java
@@ -38,7 +38,12 @@ public class DockerServiceDescriptor extends DefaultServiceDescriptor {
     /**
      * The name of the docker image to use
      */
-    private final String imageName;
+    private String imageName;
+
+    /**
+     * The image pull secret (optional)
+     */
+    private String imagePullSecret;
 
     /**The command to execute
      *
@@ -142,12 +147,16 @@ public class DockerServiceDescriptor extends DefaultServiceDescriptor {
             IODescriptor[] inputDescriptors,
             IODescriptor[] outputDescriptors
             ) {
-        this(id, name, null, null, null, null, null, null, inputDescriptors, null, outputDescriptors, null, null, null, null, null, null, null);
+        this(id, name, null, null, null, null, null, null, inputDescriptors, null, outputDescriptors, null, null, null, null, null, null, null, null);
     }
 
 
     public String getImageName() {
         return imageName;
+    }
+
+    public String getImagePullSecret() {
+        return imagePullSecret;
     }
 
     public String getCommand() {
@@ -157,4 +166,13 @@ public class DockerServiceDescriptor extends DefaultServiceDescriptor {
     public Map<String, String> getVolumes() {
         return volumes;
     }
+
+    public void setImageName(String imageName) {
+        this.imageName = imageName;
+    }
+
+    public void setImagePullSecret(String imagePullSecret) {
+        this.imagePullSecret = imagePullSecret;
+    }
+
 }

--- a/components/core-services-exec/build.gradle
+++ b/components/core-services-exec/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile "org.codehaus.groovy:groovy-all:$groovyVersion"
     compile "org.postgresql:postgresql:$postgresDriverVersion"
     compile 'com.github.docker-java:docker-java:3.0.7'
-    compile 'io.fabric8:openshift-client:4.6.2'
+    compile 'io.fabric8:openshift-client:4.7.0'
     compile 'org.yaml:snakeyaml:1.24'
     compile('io.nextflow:nextflow:0.25.4') {
         exclude group:'ch.qos.logback',module:'logback-classic'

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/ExecutableJob.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/ExecutableJob.java
@@ -213,7 +213,7 @@ public class ExecutableJob {
 
         LOG.fine("Creating container runner. image=" + image +
                  " imagePullSecret=" + imagePullSecret +
-                 " workDir='" + workDir + "'");
+                 " workdir='" + workdir + "'");
 
         ContainerRunner runner = null;
         if (CONTAINER_RUNNER_TYPE.equals("docker")) {

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/ExecutableJob.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/ExecutableJob.java
@@ -200,18 +200,25 @@ public class ExecutableJob {
     }
 
     protected ContainerRunner createContainerRunner(String image) throws IOException {
-        return createContainerRunner(image, null);
+
+        LOG.info("Creating container runner. image=" + image);
+        return createContainerRunner(image, null, null);
+
     }
 
     protected ContainerRunner createContainerRunner(String image, String imagePullSecret) throws IOException {
-        return createContainerRunner(image, null, null);
+
+        LOG.info("Creating container runner. image=" + image +
+                 " imagePullSecret=" + imagePullSecret);
+        return createContainerRunner(image, imagePullSecret, null);
+
     }
 
     protected ContainerRunner createContainerRunner(String image, String imagePullSecret, String workdir) throws IOException {
         // The CONTAINER_RUNNER_TYPE (environment variable) defines what
         // type of ContainerRunner we produce...
 
-        LOG.fine("Creating container runner. image=" + image +
+        LOG.info("Creating container runner. image=" + image +
                  " imagePullSecret=" + imagePullSecret +
                  " workdir='" + workdir + "'");
 

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/ExecutableJob.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/ExecutableJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Informatics Matters Ltd.
+ * Copyright (c) 2020 Informatics Matters Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -203,9 +203,17 @@ public class ExecutableJob {
         return createContainerRunner(image, null);
     }
 
-    protected ContainerRunner createContainerRunner(String image, String workdir) throws IOException {
+    protected ContainerRunner createContainerRunner(String image, String imagePullSecret) throws IOException {
+        return createContainerRunner(image, null, null);
+    }
+
+    protected ContainerRunner createContainerRunner(String image, String imagePullSecret, String workdir) throws IOException {
         // The CONTAINER_RUNNER_TYPE (environment variable) defines what
         // type of ContainerRunner we produce...
+
+        LOG.fine("Creating container runner. image=" + image +
+                 " imagePullSecret=" + imagePullSecret +
+                 " workDir='" + workDir + "'");
 
         ContainerRunner runner = null;
         if (CONTAINER_RUNNER_TYPE.equals("docker")) {
@@ -216,7 +224,7 @@ public class ExecutableJob {
         } else if (CONTAINER_RUNNER_TYPE.equals("openshift")) {
 
             LOG.fine("Creating OpenShiftRunner instance...");
-            runner = new OpenShiftRunner(image, workdir, workdir, jobId);
+            runner = new OpenShiftRunner(image, imagePullSecret, workdir, workdir, jobId);
 
         } else {
             throw new IOException("Unsupported ContainerRunner type: '" + CONTAINER_RUNNER_TYPE + "'");

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -630,7 +630,11 @@ public class OpenShiftRunner extends AbstractRunner {
                 .withVolumeMounts(volumeMount).build();
 
         // Here we prepare a (potentially empty) list of pull secrets
-        // for the Pod.
+        // for the Pod. We only expect one secret so the result is
+        // either an empty list of a list containing one secret name.
+        // The 'imagePullSecret' is oto the secret itself
+        // it is simply the name of a pre-deployed Kubernetes Secret object.
+        // See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
         List<LocalObjectReference> pullSecrets= new ArrayList<>();
         if (imagePullSecret != null && imagePullSecret.length() > 0) {
             pullSecrets.add(new LocalObjectReference(imagePullSecret));

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/steps/impl/DefaultDockerExecutorStep.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/steps/impl/DefaultDockerExecutorStep.java
@@ -80,10 +80,12 @@ public class DefaultDockerExecutorStep extends AbstractContainerStep {
         // Normally required when the image is located in a private Docker regsitry.
         // This will either be null or an empty string if it's not required.
         String imagePullSecret = descriptor.getImagePullSecret();
+        LOG.info("Docker image: " + image + " imagePullSecret: " + imagePullSecret);
 
         ContainerRunner containerRunner = createContainerRunner(image, imagePullSecret);
         containerRunner.init();
-        LOG.info("Docker image: " + image + ", hostWorkDir: " + containerRunner.getHostWorkDir() + ", command: " + expandedCommand);
+        LOG.info("Docker hostWorkDir: " + containerRunner.getHostWorkDir() +
+                 " command: " + expandedCommand);
 
         // add the resources
         if (descriptor.getVolumes() != null) {

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/steps/impl/DefaultDockerExecutorStep.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/steps/impl/DefaultDockerExecutorStep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Informatics Matters Ltd.
+ * Copyright (c) 2020 Informatics Matters Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,13 @@ public class DefaultDockerExecutorStep extends AbstractContainerStep {
         // screen.py '${query}' ${threshold} --d ${descriptor}
         String expandedCommand = expandCommand(command, options);
 
-        ContainerRunner containerRunner = createContainerRunner(image);
+        // Get the (Kubernetes) image pull secret name
+        // (defined and non-empty if the image needs authentication).
+        // Normally required when the image is located in a private Docker regsitry.
+        // This will either be null or an empty string if it's not required.
+        String imagePullSecret = descriptor.getImagePullSecret();
+
+        ContainerRunner containerRunner = createContainerRunner(image, imagePullSecret);
         containerRunner.init();
         LOG.info("Docker image: " + image + ", hostWorkDir: " + containerRunner.getHostWorkDir() + ", command: " + expandedCommand);
 

--- a/components/core-services-server/src/main/groovy/org/squonk/core/service/discovery/ServiceDiscoveryRouteBuilder.java
+++ b/components/core-services-server/src/main/groovy/org/squonk/core/service/discovery/ServiceDiscoveryRouteBuilder.java
@@ -160,6 +160,18 @@ public class ServiceDiscoveryRouteBuilder extends RouteBuilder {
                         throw new RuntimeException("Failed to read service descriptor");
                     }
 
+                    // If the header 'Image-Pull-Secret' exists and has a value then we assume
+                    // the service descriptor can support a pull secret and so we
+                    // insert the supplied image pull secret into the corresponding descriptor class.
+                    String imagePullSecret = exch.getIn().getHeader("Image-Pull-Secret", String.class);
+                    LOG.info("imagePullSecret is " + imagePullSecret);
+                    if (imagePullSecret != null && imagePullSecret.length() > 0) {
+                        if (baseUrl.startsWith('docker')) {
+                            LOG.info("Setting Docker imagePullSecret to " + imagePullSecret);
+                            ((DockerServiceDescriptor) sd).imagePullSecret = imagePullSecret;
+                        }
+                    }
+
                     ServiceDescriptorRegistry reg = fetchDescriptorRegistry(exch.getContext());
                     reg.init(); // this ensures the descriptors are loaded from the DB before we update anything
 

--- a/components/core-services-server/src/main/groovy/org/squonk/core/service/discovery/ServiceDiscoveryRouteBuilder.java
+++ b/components/core-services-server/src/main/groovy/org/squonk/core/service/discovery/ServiceDiscoveryRouteBuilder.java
@@ -178,7 +178,19 @@ public class ServiceDiscoveryRouteBuilder extends RouteBuilder {
                         if (baseUrl.startsWith("docker")) {
                             String imageName = ((DockerServiceDescriptor) sd).getImageName();
                             imageName = imageRegistry + "/" + imageName;
-                            LOG.info("Setting Docker imageName§ to " + imageName);
+                            LOG.info("Adding Registry to imageName " + imageName);
+                            ((DockerServiceDescriptor) sd).setImageName(imageName);
+                        }
+                    }
+                    // Is there an image tag? ('Image-Tag')
+                    // If so, replace any existing image tag with the value supplied.
+                    String imageTag = exch.getIn().getHeader("Image-Tag", String.class);
+                    if (imageTag != null && imageTag.length() > 0) {
+                        if (baseUrl.startsWith("docker")) {
+                            String imageName = ((DockerServiceDescriptor) sd).getImageName();
+                            String[] imageNameParts = imageName.split(":");
+                            imageName = imageNameParts[0] + ":" + imageTag;
+                            LOG.info("Replacing tag in imageName " + imageName);
                             ((DockerServiceDescriptor) sd).setImageName(imageName);
                         }
                     }

--- a/components/core-services-server/src/main/groovy/org/squonk/core/service/discovery/ServiceDiscoveryRouteBuilder.java
+++ b/components/core-services-server/src/main/groovy/org/squonk/core/service/discovery/ServiceDiscoveryRouteBuilder.java
@@ -160,15 +160,26 @@ public class ServiceDiscoveryRouteBuilder extends RouteBuilder {
                         throw new RuntimeException("Failed to read service descriptor");
                     }
 
-                    // If the header 'Image-Pull-Secret' exists and has a value then we assume
-                    // the service descriptor can support a pull secret and so we
+                    // Is there a pull secret header? ('Image-Pull-Secret')
+                    // If so the service descriptor can support a pull secret and so we
                     // insert the supplied image pull secret into the corresponding descriptor class.
                     String imagePullSecret = exch.getIn().getHeader("Image-Pull-Secret", String.class);
                     LOG.info("imagePullSecret is " + imagePullSecret);
                     if (imagePullSecret != null && imagePullSecret.length() > 0) {
-                        if (baseUrl.startsWith('docker')) {
+                        if (baseUrl.startsWith("docker")) {
                             LOG.info("Setting Docker imagePullSecret to " + imagePullSecret);
-                            ((DockerServiceDescriptor) sd).imagePullSecret = imagePullSecret;
+                            ((DockerServiceDescriptor) sd).setImagePullSecret(imagePullSecret);
+                        }
+                    }
+                    // Is there a registry header ('Image-Registry')?
+                    // If so prefix the image name with it.
+                    String imageRegistry = exch.getIn().getHeader("Image-Registry", String.class);
+                    if (imageRegistry != null && imageRegistry.length() > 0) {
+                        if (baseUrl.startsWith("docker")) {
+                            String imageName = ((DockerServiceDescriptor) sd).getImageName();
+                            imageName = imageRegistry + "/" + imageName;
+                            LOG.info("Setting Docker imageName§ to " + imageName);
+                            ((DockerServiceDescriptor) sd).setImageName(imageName);
                         }
                     }
 


### PR DESCRIPTION
- Docker service descriptor now contains `imagePullSecret` field
- Poster can now set headers `Image-Tag`, `Image-Registry` and `Image-Pull-Secret`
- Posted pipelines have tag appended (if there is no tag in the original image name)
- Posted pipelines are now prefixed with the registry
- Posted pipelines now have the imagePullSecret set
- OpenShiftRunner now sets pull secret in Pod