### PR TITLE
podwatcher onclose kubernetesclientexception

### DIFF
--- a/components/core-services-exec/build.gradle
+++ b/components/core-services-exec/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile "org.codehaus.groovy:groovy-all:$groovyVersion"
     compile "org.postgresql:postgresql:$postgresDriverVersion"
     compile 'com.github.docker-java:docker-java:3.0.7'
-    compile 'io.fabric8:openshift-client:4.7.0'
+    compile 'io.fabric8:openshift-client:4.9.0'
     compile 'org.yaml:snakeyaml:1.24'
     compile('io.nextflow:nextflow:0.25.4') {
         exclude group:'ch.qos.logback',module:'logback-classic'

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/AbstractRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/AbstractRunner.java
@@ -30,7 +30,7 @@ public abstract class AbstractRunner implements ContainerRunner {
     protected final String jobId;
 
     static final int RUNNER_CREATED = 0;     // Created, init() to be called
-    static final int RUNNER_RUNNNG = 1;      // execute() has been invoked
+    static final int RUNNER_RUNNING = 1;      // execute() has been invoked
     static final int RUNNER_FINISHED = 2;    // execute() complete with/without error
     static final int RUNNER_STOPPING = 3;    // stop() has been invoked
     static final int RUNNER_STOPPED = 4;     // stop() has completed

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -591,9 +591,9 @@ public class OpenShiftRunner extends AbstractRunner {
                 .withPersistentVolumeClaim(pvcSrc).build();
 
         // Container resources
-        Map<String,Quantity> limits = HashMap<String,Quantity>();
+        Map<String,Quantity> limits = new HashMap<String,Quantity>();
         limitMap.put('cpu', new Quantity(OS_POD_CPU_RESOURCE));
-        Map<String,Quantity> requests = HashMap<String,Quantity>();
+        Map<String,Quantity> requests = new HashMap<String,Quantity>();
         requestMap.put('cpu', new Quantity(OS_POD_CPU_RESOURCE));
         ResourceRequirements resources = new ResourceRequirementsBuilder()
             .withLimits(limitMap)

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -755,7 +755,7 @@ public class OpenShiftRunner extends AbstractRunner {
         if (podWatcher == null) {
             cleanup();
             isRunning = RUNNER_FINISHED;
-            throw new IllegalStateException("Exception creating PodWatcher", ex);
+            throw new IllegalStateException("Exception creating PodWatcher");
         }
 
         // Launch...
@@ -798,14 +798,14 @@ public class OpenShiftRunner extends AbstractRunner {
             // Do we need to restart the watcher?
             // i.e. has it encountered an onClose() exception?
             if (podWatcher.hasOnCloseException()) {
-                Log.warning(podName +" PodWatcher has been closed" +
+                LOG.warning(podName +" PodWatcher has been closed" +
                             " (" + podWatcher.getOnCloseExceptionMessage() + ")");
                 LOG.info(podName + " (Re-creating PodWatcher)");
                 podWatcher = createPodWatcher(podName);
                 if (podWatcher == null) {
                     // Couldn't re-create a PodWatcher -
                     // something's seriously wrong and so we must leave.
-                    Log.severe(podName +" PodWatcher could not be re-created");
+                    LOG.severe(podName +" PodWatcher could not be re-created");
                     break;
                 }
             }

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -592,9 +592,9 @@ public class OpenShiftRunner extends AbstractRunner {
 
         // Container resources
         Map<String,Quantity> limits = new HashMap<String,Quantity>();
-        limitMap.put('cpu', new Quantity(OS_POD_CPU_RESOURCE));
+        limitMap.put("cpu", new Quantity(OS_POD_CPU_RESOURCE));
         Map<String,Quantity> requests = new HashMap<String,Quantity>();
-        requestMap.put('cpu', new Quantity(OS_POD_CPU_RESOURCE));
+        requestMap.put("cpu", new Quantity(OS_POD_CPU_RESOURCE));
         ResourceRequirements resources = new ResourceRequirementsBuilder()
             .withLimits(limitMap)
             .withRequests(requestMap).build();

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -148,9 +148,10 @@ public class OpenShiftRunner extends AbstractRunner {
         // - "Complete" (Stopped, waiting for the exit code event)
         // - "Finished" (where the exit code is available)
         private String podPhase = "Waiting";
-        // The exit code of the Pod's container
-        // Assigned when the container has terminated.
-        private int containerExitCode = 1;
+        // The exit code of the Pod's container.
+        // Actually assigned when the container has terminated.
+        // The default is to assume all is well.
+        private int containerExitCode = 0;
 
         /**
          * Basic constructor.
@@ -299,8 +300,8 @@ public class OpenShiftRunner extends AbstractRunner {
 
             if (cause != null) {
                 cause.printStackTrace();
-                LOG.severe("podName=" + podName +
-                           " cause.message=" + cause.getMessage());
+                LOG.warning("podName=" + podName +
+                            " cause.message=" + cause.getMessage());
             }
             podPhase = "Finished";
 

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -591,9 +591,9 @@ public class OpenShiftRunner extends AbstractRunner {
                 .withPersistentVolumeClaim(pvcSrc).build();
 
         // Container resources
-        Map<String,Quantity> limits = new HashMap<String,Quantity>();
+        Map<String,Quantity> limitMap = new HashMap<String,Quantity>();
         limitMap.put("cpu", new Quantity(OS_POD_CPU_RESOURCE));
-        Map<String,Quantity> requests = new HashMap<String,Quantity>();
+        Map<String,Quantity> requestMap = new HashMap<String,Quantity>();
         requestMap.put("cpu", new Quantity(OS_POD_CPU_RESOURCE));
         ResourceRequirements resources = new ResourceRequirementsBuilder()
             .withLimits(limitMap)


### PR DESCRIPTION
- Handles the onClose() exception (watcher is re-created)
- Update to frabric8 4.9.0 (was 4.7.0)
- Support for SQUONK_POD_CPU_RESOURCE env (default of 1)
  so all directly-launched Pods hanve cpu request and limit of 1 (or user-defined)
- Comment updates
- Constant typo