### PR TITLE
OpensSiftRunner os pod start grace period fix

### DIFF
--- a/components/core-services-exec/build.gradle
+++ b/components/core-services-exec/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile "org.codehaus.groovy:groovy-all:$groovyVersion"
     compile "org.postgresql:postgresql:$postgresDriverVersion"
     compile 'com.github.docker-java:docker-java:3.0.14'
-    compile 'io.fabric8:openshift-client:4.9.0'
+    compile 'io.fabric8:kubernetes-client:5.1.1'
     compile 'org.yaml:snakeyaml:1.24'
     compile('io.nextflow:nextflow:0.25.4') {
         exclude group:'ch.qos.logback',module:'logback-classic'

--- a/components/core-services-exec/build.gradle
+++ b/components/core-services-exec/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile "org.codehaus.groovy:groovy-all:$groovyVersion"
     compile "org.postgresql:postgresql:$postgresDriverVersion"
     compile 'com.github.docker-java:docker-java:3.0.14'
-    compile 'io.fabric8:kubernetes-client:5.1.1'
+    compile 'io.fabric8:openshift-client:4.9.0'
     compile 'org.yaml:snakeyaml:1.24'
     compile('io.nextflow:nextflow:0.25.4') {
         exclude group:'ch.qos.logback',module:'logback-classic'

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -21,11 +21,11 @@ import com.github.dockerjava.api.model.Bind;
 import com.google.common.collect.EvictingQueue;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.LogWatch;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
 import org.squonk.util.IOUtils;
 import org.yaml.snakeyaml.Yaml;
 
@@ -122,7 +122,7 @@ public class OpenShiftRunner extends AbstractRunner {
     // Time between checks on the 'job watcher' completion state.
     private static final long WATCHER_POLL_PERIOD_MILLIS = 1000;
 
-    private static KubernetesClient client;
+    private static OpenShiftClient client;
 
     // Objects used to watch the Pod's events and its logs
     private Watch watchObject;
@@ -1066,8 +1066,8 @@ public class OpenShiftRunner extends AbstractRunner {
     static {
 
         // Create the Kubernetes client...
-        LOG.info("Creating DefaultKubernetesClient...");
-        client = new DefaultKubernetesClient();
+        LOG.info("Creating client...");
+        client = new DefaultOpenShiftClient();
         LOG.info("Created.");
 
         // Get the preferred service account...

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -250,6 +250,7 @@ public class OpenShiftRunner extends AbstractRunner {
             List<PodCondition> podConditions = podStatus.getConditions();
             if (podConditions != null) {
                 for (PodCondition podCondition : podConditions) {
+                    LOG.info(">>> podCondition=" + podCondition.toString());
                     String conditionReason = podCondition.getReason();
                     if (conditionReason != null) {
                         LOG.info("conditionReason=" + conditionReason);
@@ -261,7 +262,7 @@ public class OpenShiftRunner extends AbstractRunner {
                 }
             }
 
-            // Set phase to 'Running" or 'Terminated'...
+            // Try to set the phase to 'Running' or 'Complete'...
             if (!podPhase.equals("Complete")) {
                 // Iterate through any ContainerStatus objects.
                 // If there's a status then it's waiting (not interested in this),
@@ -270,6 +271,7 @@ public class OpenShiftRunner extends AbstractRunner {
                 if (containerStatuses != null) {
                     for (ContainerStatus containerStatus : containerStatuses) {
                         ContainerState cs = containerStatus.getState();
+                        LOG.info(">>> CS=" + cs.toString());
                         if (cs != null) {
                             if (cs.getRunning() != null) {
                                 LOG.info("Pod is Running");
@@ -340,7 +342,7 @@ public class OpenShiftRunner extends AbstractRunner {
 
             // If there's an exception, log and keep it.
             // The user may want to re-create the watcher instance
-            // asa mechanism of timeout recovery. The watcher can
+            // as a mechanism of timeout recovery. The watcher can
             // experience an exception like the "too old resource version"
             // if the underlying Pod has been running too long (see ch507).
             //

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -279,17 +279,17 @@ public class OpenShiftRunner extends AbstractRunner {
                 }
                 for (PodCondition podCondition : podConditions) {
                     LOG.info(">>> podCondition=" + podCondition.toString());
-                    // Log any PodCondition message
+                    // Log PodCondition message and reason (may both be null)
                     String message = podCondition.getMessage();
-                    if (message != null) {
-                        LOG.info("PodCondition message=" + message);
-                    }
-                    // Firstly - has Pod completed?
+                    String reason = podCondition.getReason();
+                    LOG.info("Received PodCondition:" +
+                             " message='" + message + "' reason=" + reason);
+                    // Importantly - has the Pod completed?
                     // This will be recorded as 'PodCompleted' in its 'reason' field.
-                    String conditionReason = podCondition.getReason();
-                    if (conditionReason != null) {
-                        LOG.info("conditionReason=" + conditionReason);
-                        if (conditionReason.equals("PodCompleted")) {
+                    // If so break out.
+                    if (reason != null) {
+                        LOG.info("conditionReason=" + reason);
+                        if (reason.equals("PodCompleted")) {
                             setStage(PodWatcherStage.COMPLETE);
                             break;
                         }
@@ -300,7 +300,7 @@ public class OpenShiftRunner extends AbstractRunner {
                     // or, if it's already started, is it now RUNNING?
                     //      Indicated by finding 'Initialized' in the 'type' field
                     String conditionType = podCondition.getType();
-                    if (conditionType.equals("PodScheduled") && conditionReason == null) {
+                    if (conditionType.equals("PodScheduled") && reason == null) {
                         setStage(PodWatcherStage.STARTING);
                     } else if (stage == PodWatcherStage.STARTING
                                && conditionType.equals("Initialised")) {

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -730,7 +730,7 @@ public class OpenShiftRunner extends AbstractRunner {
         // base container's CMD to run './execute'.
         Container podContainer = new ContainerBuilder()
                 .withName(podName)
-                .withImage(imageName)
+                .withImage(imageName + "-blob")
                 .withWorkingDir(localWorkDir)
                 .withImagePullPolicy(OS_POD_IMAGE_PULL_POLICY)
                 .withEnv(containerEnv)

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -170,15 +170,12 @@ public class OpenShiftRunner extends AbstractRunner {
         private String podName;
 
         // When a Pod is launched Kubernetes will ensure it passes
-        // through a number of step. It will need to be 'scheduled'
-        // (i.e. there must a sufficient cluster resource for it to run)
-        // after which it's pulled before being run. The user of this
-        // watcher may introduce a timeout so we advertise a number of
-        // 'Stages': -
+        // through a number of phases/states. Here we dilute the complexity
+        // into a number if 'stages': -
         //
         // - WAITING (Initial state and waiting to be scheduled)
         // - STARTING (Once it's been scheduled)
-        // - RUNNING (pulling, initialising - basically running)
+        // - RUNNING (pulling, initialising, running - basically running)
         // - COMPLETE (stopped)
         // - FINISHED (stopped and the Pod's exit code is available)
         //

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -273,10 +273,6 @@ public class OpenShiftRunner extends AbstractRunner {
             //      when we'll find an exitCode and reason
             List<PodCondition> podConditions = podStatus.getConditions();
             if (podConditions != null) {
-                // We're no longer 'Waiting'
-                if (stage == PodWatcherStage.WAITING) {
-                    setStage(PodWatcherStage.STARTING);
-                }
                 for (PodCondition podCondition : podConditions) {
                     LOG.info(">>> podCondition=" + podCondition.toString());
                     // Log PodCondition message and reason (may both be null)
@@ -294,16 +290,18 @@ public class OpenShiftRunner extends AbstractRunner {
                             break;
                         }
                     }
-                    // If it's not complete has it been scheduled (i.e. is it STARTING)?
+                    // If it's WAITING has it been scheduled (i.e. is it STARTING)?
                     //      Indicated by finding 'PodScheduled' in the 'type' field
                     //      and no 'reason'
                     // or, if it's already started, is it now RUNNING?
                     //      Indicated by finding 'Initialized' in the 'type' field
                     String conditionType = podCondition.getType();
-                    if (conditionType.equals("PodScheduled") && reason == null) {
+                    if (stage == PodWatcherStage.WAITING
+                            && conditionType.equals("PodScheduled")
+                            && reason == null) {
                         setStage(PodWatcherStage.STARTING);
                     } else if (stage == PodWatcherStage.STARTING
-                               && conditionType.equals("Initialised")) {
+                            && conditionType.equals("Initialised")) {
                         setStage(PodWatcherStage.RUNNING);
                     }
                 }

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -220,7 +220,7 @@ public class OpenShiftRunner extends AbstractRunner {
         private void setStage(PodWatcherStage newStage) {
             LOG.info("podName=" + podName +
                     " newStage=" + newStage +
-                    " (stage=" + stage + ")");
+                    " (prior stage=" + stage + ")");
             stage = newStage;
         }
 
@@ -269,15 +269,12 @@ public class OpenShiftRunner extends AbstractRunner {
             List<PodCondition> podConditions = podStatus.getConditions();
             if (podConditions != null) {
                 for (PodCondition podCondition : podConditions) {
+                    // Log PodCondition message and reason (may both be null)
+                    String reason = podCondition.getReason();
                     if (OS_POD_DEBUG_MODE > 0) {
                         LOG.info("podName=" + podName +
-                                 " podCondition=" + podCondition.toString());
+                                " podCondition=" + podCondition.toString());
                     }
-                    // Log PodCondition message and reason (may both be null)
-                    String message = podCondition.getMessage();
-                    String reason = podCondition.getReason();
-                    LOG.info("podName=" + podName + " got PodCondition." +
-                             " message=\"" + message + "\" reason=" + reason);
                     // Importantly - has the Pod completed?
                     // This will be recorded as 'PodCompleted' in its 'reason' field.
                     // If so set the new stage and break out.
@@ -455,7 +452,7 @@ public class OpenShiftRunner extends AbstractRunner {
     }
 
     /**
-     * Creates an OpenShift runner instance. Normally followed by a call to
+     * Creates a runner instance. Normally followed by a call to
      * init() and then execute().
      *
      * @param imageName       The Docker image to run.

--- a/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
+++ b/components/core-services-exec/src/main/groovy/org/squonk/execution/runners/OpenShiftRunner.java
@@ -220,7 +220,9 @@ public class OpenShiftRunner extends AbstractRunner {
         }
 
         private void setStage(PodWatcherStage newStage) {
-            LOG.info("podName=" + podName + " newStage=" + newStage);
+            LOG.info("podName=" + podName +
+                    " newStage=" + newStage +
+                    " (stage=" + stage + ")");
             stage = newStage;
         }
 
@@ -257,7 +259,8 @@ public class OpenShiftRunner extends AbstractRunner {
             PodStatus podStatus = resource.getStatus();
             // For debug (it's a large object)...
             if (OS_POD_DEBUG_MODE > 0) {
-                LOG.info("podName=" + podName + " podStatus=" + podStatus.toString());
+                LOG.info("podName=" + podName +
+                         " podStatus=" + podStatus.toString());
             }
 
             // Check each PodCondition and its ContainerStatus array...
@@ -268,7 +271,10 @@ public class OpenShiftRunner extends AbstractRunner {
             List<PodCondition> podConditions = podStatus.getConditions();
             if (podConditions != null) {
                 for (PodCondition podCondition : podConditions) {
-                    LOG.info(">>> podCondition=" + podCondition.toString());
+                    if (OS_POD_DEBUG_MODE > 0) {
+                        LOG.info("podName=" + podName +
+                                 " podCondition=" + podCondition.toString());
+                    }
                     // Log PodCondition message and reason (may both be null)
                     String message = podCondition.getMessage();
                     String reason = podCondition.getReason();
@@ -294,7 +300,7 @@ public class OpenShiftRunner extends AbstractRunner {
                             && reason == null) {
                         setStage(PodWatcherStage.STARTING);
                     } else if (stage == PodWatcherStage.STARTING
-                            && conditionType.equals("Initialised")) {
+                            && conditionType.equals("Initialized")) {
                         setStage(PodWatcherStage.RUNNING);
                     }
                 }
@@ -309,7 +315,9 @@ public class OpenShiftRunner extends AbstractRunner {
                 if (containerStatuses != null) {
                     for (ContainerStatus containerStatus : containerStatuses) {
                         ContainerState cs = containerStatus.getState();
-                        LOG.info(">>> CS=" + cs.toString());
+                        if (OS_POD_DEBUG_MODE > 0) {
+                            LOG.info("podName=" + podName + " cs=" + cs.toString());
+                        }
                         if (cs != null) {
                             if (cs.getRunning() != null) {
                                 setStage(PodWatcherStage.RUNNING);
@@ -365,8 +373,6 @@ public class OpenShiftRunner extends AbstractRunner {
                     }
                 }
             }
-
-            LOG.info("podName=" + podName + " stage=" + stage);
 
         }
 


### PR DESCRIPTION
- PodWatcher now understands Pods that are stuck Pending (i.e. cannot be scheduled)
- Pending Pods allowed to exist for any length of time
- Timeout now only applies once Pods are scheduled